### PR TITLE
[#1274] Implement `/packages/stats` returning `package_registry.get_stats`

### DIFF
--- a/conductor/blueprints/package/blueprint.py
+++ b/conductor/blueprints/package/blueprint.py
@@ -101,6 +101,10 @@ def run_hooks():
     return jsonpify(controllers.run_hooks(id, jwt))
 
 
+def stats():
+    return jsonpify(controllers.stats())
+
+
 def create():
     """Create blueprint.
     """
@@ -122,6 +126,8 @@ def create():
         'delete', 'delete', delete_package, methods=['POST'])
     blueprint.add_url_rule(
         'run-hooks', 'run-hooks', run_hooks, methods=['POST'])
+    blueprint.add_url_rule(
+        'stats', 'stats', stats, methods=['GET'])
 
     # Return blueprint
     return blueprint

--- a/conductor/blueprints/package/controllers.py
+++ b/conductor/blueprints/package/controllers.py
@@ -151,3 +151,7 @@ def run_hooks(name, token):
     return {'success': True,
             'response': response.text,
             'payload': json_ld_payload}
+
+
+def stats():
+    return package_registry.get_stats()

--- a/tests/module/blueprints/package/test_controllers.py
+++ b/tests/module/blueprints/package/test_controllers.py
@@ -204,3 +204,9 @@ class PublishDeleteAPITests(unittest.TestCase):
         module.toggle_publish(self.DATASET_NAME, token, publish=False)
         pkg = self.pr.get_package(self.DATASET_NAME)
         assert(pkg.get('private') is True)
+
+
+class StatsTests(unittest.TestCase):
+    def test__stats__delegates_to_package_registry(self):
+        with patch('conductor.blueprints.package.models.package_registry.get_stats') as get_stats_mock:
+            assert module.stats() == get_stats_mock()


### PR DESCRIPTION
The new endpoint just delegates to `os_package_registry`. The assumption is
that the API and tests are defined there.

openspending/openspending#1274