### PR TITLE
Specify Elasticsearch version for travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,13 @@ python:
 addons:
     postgresql: "9.4"
 
-# services:
-#     - elasticsearch
-
 env:
     global:
         - OS_CONDUCTOR_ENGINE=postgresql://postgres@/postgres
         - OS_ELASTICSEARCH_ADDRESS=localhost:9200
 
 before_install:
+  - sudo rm -f /etc/boto.cfg
   - curl -O https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.5.2.deb && sudo dpkg -i --force-confnew elasticsearch-1.5.2.deb && sudo service elasticsearch restart
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,16 @@ python:
 addons:
     postgresql: "9.4"
 
-services:
-    - elasticsearch
+# services:
+#     - elasticsearch
 
 env:
     global:
         - OS_CONDUCTOR_ENGINE=postgresql://postgres@/postgres
         - OS_ELASTICSEARCH_ADDRESS=localhost:9200
+
+before_install:
+  - curl -O https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.5.2.deb && sudo dpkg -i --force-confnew elasticsearch-1.5.2.deb && sudo service elasticsearch restart
 
 install:
   - pip install --upgrade -r requirements.dev.txt


### PR DESCRIPTION
This PR ensures the version of elasticsearch used in travis is the same as that used in production (1.5.x). os-conductor tests don't pass with recent versions of elasticsearch (5.x and 6.x), which are now the default install for travis builds.

This PR also fixes a problem with boto not installing correctly. See https://github.com/travis-ci/travis-ci/issues/7940 for details.