### PR TITLE
Improve containerisation of os-conductor

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.env
+.git
+.tox
+.cache
+*.egg-info/
+flask_session
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ shippable/
 
 # flask
 flask_session/
+
+.env

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ env:
     global:
         - OS_CONDUCTOR_ENGINE=postgresql://postgres@/postgres
         - OS_ELASTICSEARCH_ADDRESS=localhost:9200
+        - OS_API_URL=http://localhost:8000
+        - OS_CONDUCTOR_URL=http://localhost:8000
 
 before_install:
   - sudo rm -f /etc/boto.cfg

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,9 @@ ENV OS_API=os-api-loader:8000
 ENV OS_CONDUCTOR=os-conductor:8000
 
 COPY docker/startup.sh /startup.sh
+COPY docker/docker-entrypoint.sh /entrypoint.sh
 
 EXPOSE 8000
 
 CMD ["/startup.sh"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,6 @@ RUN pip install -r requirements.txt
 
 ADD . .
 
-ENV OS_CONDUCTOR_CACHE=cache:11211
-ENV OS_API=os-api-loader:8000
-ENV OS_CONDUCTOR=os-conductor:8000
-
 COPY docker/startup.sh /startup.sh
 COPY docker/docker-entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,32 @@
-FROM gliderlabs/alpine:3.4
+FROM python:3.6-alpine
 
-RUN apk add --update python3 git libpq
-RUN apk add --update --virtual=build-dependencies wget libffi libffi-dev ca-certificates python3-dev postgresql-dev build-base
+RUN apk --no-cache add \
+    python3 \
+    git \
+    libpq \
+    wget \
+    libffi \
+    libffi-dev \
+    ca-certificates \
+    python3-dev \
+    postgresql-dev \
+    build-base \
+    bash \
+    curl
 RUN update-ca-certificates
-RUN wget "https://bootstrap.pypa.io/get-pip.py" -O /dev/stdout | python3
-RUN python3 --version
-RUN pip3 --version
-RUN pip3 install psycopg2
-RUN pip3 install --upgrade pip
-RUN pip3 install gunicorn
-RUN pip3 install python-memcached
-RUN pip3 install cryptography
-RUN ls -la && ls -la / && mount
-RUN git clone http://github.com/openspending/os-conductor.git app
-RUN cd app && pip install -r requirements.txt
-RUN apk del build-dependencies
-RUN rm -rf /var/cache/apk/*
+
+WORKDIR /app
+ADD requirements.txt .
+RUN pip install -r requirements.txt
+
+ADD . .
 
 ENV OS_CONDUCTOR_CACHE=cache:11211
 ENV OS_API=os-api-loader:8000
 ENV OS_CONDUCTOR=os-conductor:8000
 
-ADD docker/startup.sh /startup.sh
+COPY docker/startup.sh /startup.sh
 
 EXPOSE 8000
 
-CMD /startup.sh
+CMD ["/startup.sh"]

--- a/README.md
+++ b/README.md
@@ -8,8 +8,58 @@
 
 A set of integration web services for OpenSpending, responsible for identity, notification, and access control.
 
-## Quick start
+## Quick start for development
 
 Clone the repo, install dependencies from pypi, and run the server. See the [docs](http://docs.openspending.org/en/latest/developers/conductor/) for more information.
+
+### Environmental Variables
+
+OS Conductor requires environmental variables to be set, either in the local environment or in a `.env` file in the root directory.
+
+```ini
+# Required settings
+
+# Base URL for the application, e.g. 'http://localhost' or 'https://openspending.org'
+OS_BASE_URL=
+# Address for the postgres instance, e.g. postgresql://postgres@db/postgres
+OS_CONDUCTOR_ENGINE=
+# Address for ElasticSearch instance
+OS_ELASTICSEARCH_ADDRESS=
+# Address for the OS API service (configured as a 'loader'), e.g. http://os-api-loader:8000
+OS_API_URL=
+
+# OAuth credentials. See the OAuth Credentials section below for details.
+OS_CONDUCTOR_SECRETS_0=
+OS_CONDUCTOR_SECRETS_1=
+OS_CONDUCTOR_SECRETS_2=
+OS_CONDUCTOR_SECRETS_3=
+
+# AWS S3 credentials
+OS_ACCESS_KEY_ID=
+OS_SECRET_ACCESS_KEY=
+OS_S3_HOSTNAME=
+OS_STORAGE_BUCKET_NAME=
+
+# Optional settings
+
+# Address for memcached server, e.g. http://cache:11211
+OS_CONDUCTOR_CACHE=
+```
+
+
+### OAuth Credentials
+
+OS Conductor needs credentials for authentication and authorization tasks. Credential values is set on `OS_CONDUCTOR_SECRETS_<n>` env vars. We provide a python script to help generate these values in `docker/secrets/generate-secrets/to_env_vars.py`.
+
+1. Create a [Google OAuth Credentials](https://console.developers.google.com/apis/credentials) and retain the Client ID and Secret Key
+2. Paste the Client ID and Secret Key values in to `google.key` and `google.secret.key` files respectively within the `generate-secrets` directory.
+3. Run the python script:
+
+```bash
+$ cd docker/secrets/generate-secrets
+$ python ./to_env_vars.py
+```
+
+4. Copy the generated env var key/values into your local environment or `.env` file in the root directory.
 
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ OS Conductor requires environmental variables to be set, either in the local env
 
 # Base URL for the application, e.g. 'http://localhost' or 'https://openspending.org'
 OS_BASE_URL=
+# URL for this os-conductor instance within the network, used for callbacks. e.g. http://os-conductor:8000
+OS_CONDUCTOR_URL=
 # Address for the postgres instance, e.g. postgresql://postgres@db/postgres
 OS_CONDUCTOR_ENGINE=
 # Address for ElasticSearch instance

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ OS_STORAGE_BUCKET_NAME=
 
 # Address for memcached server, e.g. http://cache:11211
 OS_CONDUCTOR_CACHE=
+
+# If this env var exists, the entrypoint script will check whether ElasticSearch is healthy before allowing os-conductor to start.
+OS_CHECK_ES_HEALTHY=
 ```
 
 

--- a/conductor/app.py
+++ b/conductor/app.py
@@ -1,5 +1,10 @@
 import os
 
+from dotenv import load_dotenv
+
+dotenv_path = os.path.join(os.path.dirname(__file__), '../.env')
+load_dotenv(dotenv_path)
+
 from flask import Flask
 from flask.ext.cors import CORS
 from flask.ext.session import Session

--- a/conductor/app.py
+++ b/conductor/app.py
@@ -5,6 +5,7 @@ from dotenv import load_dotenv
 dotenv_path = os.path.join(os.path.dirname(__file__), '../.env')
 load_dotenv(dotenv_path)
 
+# pylama:ignore=E402
 from flask import Flask
 from flask.ext.cors import CORS
 from flask.ext.session import Session

--- a/conductor/blueprints/datastore/controllers.py
+++ b/conductor/blueprints/datastore/controllers.py
@@ -7,7 +7,7 @@ try:
     from urllib.parse import urlparse, parse_qs
 except ImportError:
     from urlparse import urlparse, parse_qs
-from flask import request, Response
+from flask import Response
 from ... import config
 from . import services
 
@@ -33,7 +33,6 @@ def authorize(connection, auth_token, req_payload):
     """Authorize a client for the file uploading.
     """
     # Verify client, deny access if not verified
-
     try:
         # Get request payload
         owner = req_payload.get('metadata', {}).get('owner')
@@ -76,7 +75,6 @@ def authorize(connection, auth_token, req_payload):
         return json.dumps(res_payload)
 
     except Exception as exception:
-
         raise
         # TODO: use logger
         # Log bad request exception
@@ -117,7 +115,6 @@ def info(auth_token):
         return json.dumps(response_payload)
 
     except Exception as exception:
-
         raise
         # TODO: use logger
         # Log bad request exception

--- a/conductor/blueprints/datastore/controllers.py
+++ b/conductor/blueprints/datastore/controllers.py
@@ -7,7 +7,8 @@ try:
     from urllib.parse import urlparse, parse_qs
 except ImportError:
     from urlparse import urlparse, parse_qs
-from flask import Response
+# request imported here so it can be mocked in tests
+from flask import request, Response  # noqa
 from ... import config
 from . import services
 

--- a/conductor/blueprints/package/blueprint.py
+++ b/conductor/blueprints/package/blueprint.py
@@ -13,8 +13,7 @@ if 'OS_CONDUCTOR_CACHE' in os.environ:
 else:
     cache = SimpleCache()
 
-os_conductor = os.environ.get('OS_CONDUCTOR')
-
+os_conductor = os.environ.get('OS_CONDUCTOR_URL')
 
 logging.info('CACHE=%r', cache)
 
@@ -36,7 +35,7 @@ def upload():
         abort(400)
     if jwt is None:
         abort(403)
-    callback = 'http://'+os_conductor+url_for('.callback')
+    callback = os_conductor+url_for('.callback')
     ret = controllers.upload(datapackage, callback, jwt, cache_set)
     return jsonpify(ret)
 

--- a/conductor/blueprints/package/controllers.py
+++ b/conductor/blueprints/package/controllers.py
@@ -9,7 +9,7 @@ from six import StringIO
 from conductor.blueprints.user.controllers import PUBLIC_KEY
 from .models import package_registry
 
-os_api = os.environ.get('OS_API')
+os_api_url = os.environ.get('OS_API_URL')
 
 
 def upload(datapackage, callback, token, cache_set):
@@ -36,7 +36,7 @@ def upload(datapackage, callback, token, cache_set):
             'package': datapackage,
             'callback': callback
         }
-        load_url = 'http://'+os_api+'/api/3/loader/'
+        load_url = os_api_url+'/api/3/loader/'
         response = requests.get(load_url, params=params)
         if response.status_code == 200:
             key = 'os-conductor:package:'+datapackage

--- a/conductor/blueprints/user/blueprint.py
+++ b/conductor/blueprints/user/blueprint.py
@@ -7,11 +7,11 @@ from flask.ext.jsonpify import jsonpify
 
 from conductor.blueprints.user import controllers
 
-os_conductor = os.environ.get('OS_EXTERNAL_ADDRESS')
+os_conductor = os.environ.get('OS_BASE_URL')
 
 
 def get_callback_url():
-    return 'https://'+os_conductor+url_for('oauth.callback')
+    return os_conductor + url_for('oauth.callback')
 
 
 def create():

--- a/conductor/blueprints/user/controllers.py
+++ b/conductor/blueprints/user/controllers.py
@@ -24,8 +24,6 @@ def readfile_or_default(filename, default):
         return default
 
 
-os_conductor = os.environ.get('OS_EXTERNAL_ADDRESS')
-
 try:
     credentials = ''.join(os.environ.get('OS_CONDUCTOR_SECRETS_%d' % i)
                           for i in range(4)).encode('ascii')

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -47,5 +47,8 @@ waitForElasticsearch() {
 
 # Main
 readParams
+if [ ${OS_CHECK_ES_HEALTHY+x} ]
+then
 waitForElasticsearch $OS_ELASTICSEARCH_ADDRESS
+fi
 exec "$@"

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -17,18 +17,15 @@ checkHost() {
 
 readParams() {
   checkHost "OS_ELASTICSEARCH_ADDRESS"
-
-  # Use default ports if not specified.
-  : ${ES_PORT:=9200}
 }
 
 # Wait for elasticsearch to start. It requires that the status be either green
 # or yellow.
 waitForElasticsearch() {
-  echo -n "Waiting on $1($1:${ES_PORT}) to start."
+  echo -n "Waiting on $1 to start."
   for ((i=1;i<=300;i++))
   do
-    health=$(curl --silent "http://$1:${ES_PORT}/_cat/health" | awk '{print $4}')
+    health=$(curl --silent "http://$1/_cat/health" | awk '{print $4}')
     if [[ "$health" == "green" ]] || [[ "$health" == "yellow" ]]
     then
       echo
@@ -43,7 +40,7 @@ waitForElasticsearch() {
 
   echo
   echo >&2 'Elasticsearch is not running or is not healthy.'
-  echo >&2 "Address: ${OS_ELASTICSEARCH_ADDRESS}:${ES_PORT}"
+  echo >&2 "Address: ${OS_ELASTICSEARCH_ADDRESS}"
   echo >&2 "$health"
   exit 1
 }

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -e
+
+# This script is the entrypoint to the os-conductor Docker container. This will
+# verify that the Elasticsearch environment variable is set and that
+# Elasticsearch is running before executing the command provided to the docker
+# container.
+
+# Read parameters from the environment and validate them.
+checkHost() {
+    if [ -z "$$1" ]; then
+        echo >&2 'Error: missing required $1 environment variable'
+        echo >&2 '  Did you forget to -e $1=... ?'
+        exit 1
+    fi
+}
+
+readParams() {
+  checkHost "OS_ELASTICSEARCH_ADDRESS"
+
+  # Use default ports if not specified.
+  : ${ES_PORT:=9200}
+}
+
+# Wait for elasticsearch to start. It requires that the status be either green
+# or yellow.
+waitForElasticsearch() {
+  echo -n "Waiting on $1($1:${ES_PORT}) to start."
+  for ((i=1;i<=300;i++))
+  do
+    health=$(curl --silent "http://$1:${ES_PORT}/_cat/health" | awk '{print $4}')
+    if [[ "$health" == "green" ]] || [[ "$health" == "yellow" ]]
+    then
+      echo
+      echo "Elasticsearch is ready!"
+      return 0
+    fi
+
+    ((i++))
+    echo -n '.'
+    sleep 1
+  done
+
+  echo
+  echo >&2 'Elasticsearch is not running or is not healthy.'
+  echo >&2 "Address: ${OS_ELASTICSEARCH_ADDRESS}:${ES_PORT}"
+  echo >&2 "$health"
+  exit 1
+}
+
+# Main
+readParams
+waitForElasticsearch $OS_ELASTICSEARCH_ADDRESS
+exec "$@"

--- a/docker/secrets/.gitignore
+++ b/docker/secrets/.gitignore
@@ -1,2 +1,3 @@
 prod-secrets/
-
+generate-secrets/*
+!generate-secrets/to_env_vars.py

--- a/docker/secrets/generate-secrets/to_env_vars.py
+++ b/docker/secrets/generate-secrets/to_env_vars.py
@@ -1,0 +1,24 @@
+import json
+import zlib
+import base64
+
+secrets = {}
+
+for x in ['google.key', 'google.secret.key', 'private.pem', 'public.pem']:
+   secrets[x] = open(x).read().strip()
+
+prefix = 'OS_CONDUCTOR_SECRETS_'
+
+encoded = json.dumps(secrets).encode('ascii')
+encoded = zlib.compress(encoded)
+encoded = base64.encodebytes(encoded)
+encoded = encoded.replace(b'\n',b'')
+chunk = (len(encoded)+4)//4
+print(chunk)
+
+i=0
+while len(encoded)>0:
+   var = '%s%i' % (prefix,i)
+   print('%s="%s"' % (var, encoded[:chunk].decode('ascii')))
+   encoded = encoded[chunk:]
+   i+=1

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -1,23 +1,13 @@
 #!/bin/sh
 set -e
 
-ls $WORKDIR/.git > /dev/null && cd $WORKDIR || cd /app
+cd $WORKDIR || cd /app
 echo working from `pwd`
 echo DB: $OS_CONDUCTOR_ENGINE
 
-if [ ! -z "$GIT_REPO" ]; then
-    rm -rf /remote || true && git clone $GIT_REPO /remote && cd /remote;
-    if [ ! -z "$GIT_BRANCH" ]; then
-        git checkout origin/$GIT_BRANCH
-    fi
-    pip install -r requirements.txt
-    cat conductor/blueprints/user/lib/lib.js | sed s~/openspending.org~/staging.openspending.org~ > lib.js.tmp
-    mv -f lib.js.tmp conductor/blueprints/user/lib/lib.js
-else
-    ( cd /repos/os-conductor && pip install -r requirements.txt &&
-      cat conductor/blueprints/user/lib/lib.js | sed s~/openspending.org~/dev.openspending.org~ > lib.js.tmp &&
-      mv -f lib.js.tmp conductor/blueprints/user/lib/lib.js
-    ) || true
-fi
+echo Setting base url to $OS_BASE_URL
+cat conductor/blueprints/user/lib/lib.js | sed 's,https://openspending.org,'"$OS_BASE_URL"',' > lib.js.tmp &&
+mv -f lib.js.tmp conductor/blueprints/user/lib/lib.js
+
 
 gunicorn -w 1 conductor.server:app -b 0.0.0.0:8000

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,5 @@ elasticsearch>=1.0.0,<2.0.0
 os-package-registry>=0.0.12
 blinker>=1.1
 python-dotenv
+gunicorn
+python-memcached

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ cryptography
 elasticsearch>=1.0.0,<2.0.0
 os-package-registry>=0.0.12
 blinker>=1.1
+python-dotenv


### PR DESCRIPTION
- Make better use of Dockerfile caching and add .dockerignore file
- App-level dependencies removed from Dockerfile, should be handled by app (requirements.txt for python).
- entrypoint script to check health of dependent services
- Consolidates env var usage with rest of platform.
- Add documentation for env var and secret generation

Part of openspending/openspending#1340.