### PR TITLE
'/packager/update_params' endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .python-version
+.noseids
 
 # Translations
 *.mo
@@ -73,3 +74,4 @@ shippable/
 flask_session/
 
 .env
+repos/

--- a/conductor/blueprints/package/blueprint.py
+++ b/conductor/blueprints/package/blueprint.py
@@ -109,6 +109,8 @@ def update_params():
     jwt = request.values.get('jwt')
     datapackage = request.values.get('id')
     params = request.get_json()
+    if 'params' not in params or not isinstance(params['params'], str):
+        abort(400, "No 'params' key or bad params value.")
     if datapackage is None:
         abort(400)
     if jwt is None:

--- a/conductor/blueprints/package/blueprint.py
+++ b/conductor/blueprints/package/blueprint.py
@@ -105,6 +105,19 @@ def stats():
     return jsonpify(controllers.stats())
 
 
+def update_params():
+    jwt = request.values.get('jwt')
+    datapackage = request.values.get('id')
+    params = request.get_json()
+    if datapackage is None:
+        abort(400)
+    if jwt is None:
+        abort(403)
+
+    ret = controllers.update_params(datapackage, jwt, params)
+    return jsonpify(ret)
+
+
 def create():
     """Create blueprint.
     """
@@ -128,6 +141,8 @@ def create():
         'run-hooks', 'run-hooks', run_hooks, methods=['POST'])
     blueprint.add_url_rule(
         'stats', 'stats', stats, methods=['GET'])
+    blueprint.add_url_rule(
+        'update_params', 'update_params', update_params, methods=['POST'])
 
     # Return blueprint
     return blueprint

--- a/conductor/blueprints/package/controllers.py
+++ b/conductor/blueprints/package/controllers.py
@@ -106,10 +106,9 @@ def toggle_publish(name, token, toggle=False, publish=False):
 
 
 def update_params(name, token, params):
-    '''
-    Update package.defaultParams for the passed `name`. Only the owner can
-    update.
-    '''
+    """
+    Update package.defaultParams for the passed `name`. Only owner can update.
+    """
     try:
         token = jwt.decode(token.encode('ascii'),
                            PUBLIC_KEY,

--- a/conductor/blueprints/package/controllers.py
+++ b/conductor/blueprints/package/controllers.py
@@ -120,12 +120,20 @@ def update_params(name, token, params):
     except jwt.InvalidTokenError:
         return None
 
-    _, _, datapackage, _, _, _, _, _ = package_registry.get_raw(name)
+    try:
+        _, _, datapackage, *_ = package_registry.get_raw(name)
+    except KeyError:
+        # Can't find package by `name`
+        return None
+
     datapackage['defaultParams'] = params
 
     package_registry.update_model(name, datapackage=datapackage)
-    # Clear the cached entry for this package
-    api_cache.clear(name)
+    # Clear the cached entry for this package is api_cache isn't None.
+    try:
+        api_cache.clear(name)
+    except AttributeError:
+        pass
     return {'success': True}
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ psycopg2
 cryptography
 elasticsearch>=1.0.0,<2.0.0
 os-package-registry>=0.0.12
+os-api-cache>=0.0.6
 blinker>=1.1
 python-dotenv
 gunicorn

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,9 @@
+# Quiet down third-party logging in test output.
+
+import logging
+
+es_logger = logging.getLogger('elasticsearch')
+es_logger.setLevel(logging.WARNING)
+
+urllib3_logger = logging.getLogger('urllib3')
+urllib3_logger.setLevel(logging.WARNING)

--- a/tests/module/blueprints/package/test_controllers.py
+++ b/tests/module/blueprints/package/test_controllers.py
@@ -7,7 +7,6 @@ import jwt
 from elasticsearch import Elasticsearch, NotFoundError
 from os_package_registry import PackageRegistry
 from ..config import LOCAL_ELASTICSEARCH
-from werkzeug.exceptions import BadRequest, NotFound, Forbidden
 
 try:
     from unittest.mock import Mock, patch
@@ -21,7 +20,8 @@ module = import_module('conductor.blueprints.package.controllers')
 Response = namedtuple('Response', ['status_code'])
 _cache = {}
 callback = 'http://conductor/callback'
-token = jwt.encode({'userid': 'owner'}, PRIVATE_KEY, algorithm='RS256').decode('ascii')
+token = jwt.encode({'userid': 'owner'},
+                   PRIVATE_KEY, algorithm='RS256').decode('ascii')
 
 
 def cache_get(key):
@@ -64,7 +64,8 @@ class ApiloadTest(unittest.TestCase):
     def test___load___good_request(self):
         api_load = module.upload
         self.requests.get = Mock(return_value=Response(200))
-        self.assertResponse(api_load('bla', callback, token, cache_set), 'queued', 0)
+        self.assertResponse(api_load('bla', callback, token, cache_set),
+                            'queued', 0)
 
     # def test___load___bad_request(self):
     #     api_load = module.upload
@@ -79,7 +80,8 @@ class ApiloadTest(unittest.TestCase):
     def test___callback___server_down(self):
         api_load = module.upload
         self.requests.get = Mock(return_value=Response(499))
-        self.assertResponse(api_load('bla', callback, token, cache_set), 'fail', error='HTTP 499')
+        self.assertResponse(api_load('bla', callback, token, cache_set),
+                            'fail', error='HTTP 499')
 
     def test___poll___good_request(self):
         api_load = module.upload
@@ -100,7 +102,8 @@ class ApiloadTest(unittest.TestCase):
     def test___callback___no_update(self):
         # No parameters
         api_callback = module.upload_status_update
-        self.assertEquals(api_callback('bla4', None, None, 0, cache_get, cache_set), None)
+        self.assertEquals(api_callback('bla4', None, None, 0, cache_get,
+                                       cache_set), None)
 
         api_poll = module.upload_status
         self.assertEquals(api_poll('bla4', cache_get), None)
@@ -108,7 +111,8 @@ class ApiloadTest(unittest.TestCase):
     def test___callback___just_status(self):
         # No parameters
         api_callback = module.upload_status_update
-        self.assertEquals(api_callback('bla5', 'status1', None, 0, cache_get, cache_set), None)
+        self.assertEquals(api_callback('bla5', 'status1', None, 0, cache_get,
+                                       cache_set), None)
 
         api_poll = module.upload_status
         self.assertResponse(api_poll('bla5', cache_get), 'status1', 0)
@@ -116,7 +120,8 @@ class ApiloadTest(unittest.TestCase):
     def test___callback___progress(self):
         # No parameters
         api_callback = module.upload_status_update
-        self.assertEquals(api_callback('bla6', 'status2', None, 123, cache_get, cache_set), None)
+        self.assertEquals(api_callback('bla6', 'status2', None, 123, cache_get,
+                                       cache_set), None)
 
         api_poll = module.upload_status
         self.assertResponse(api_poll('bla6', cache_get), 'status2', 123)
@@ -124,7 +129,8 @@ class ApiloadTest(unittest.TestCase):
     def test___callback___errormsg_wrong_status(self):
         # No parameters
         api_callback = module.upload_status_update
-        self.assertEquals(api_callback('bla7', 'status3', 'wtf', 123, cache_get, cache_set), None)
+        self.assertEquals(api_callback('bla7', 'status3', 'wtf', 123,
+                                       cache_get, cache_set), None)
 
         api_poll = module.upload_status
         self.assertResponse(api_poll('bla7', cache_get), 'status3', 123)
@@ -132,7 +138,8 @@ class ApiloadTest(unittest.TestCase):
     def test___callback___error_good_status(self):
         # No parameters
         api_callback = module.upload_status_update
-        self.assertEquals(api_callback('bla8', 'fail', 'wtf8', 0, cache_get, cache_set), None)
+        self.assertEquals(api_callback('bla8', 'fail', 'wtf8', 0, cache_get,
+                                       cache_set), None)
 
         api_poll = module.upload_status
         self.assertResponse(api_poll('bla8', cache_get), 'fail', 0, 'wtf8')
@@ -140,7 +147,7 @@ class ApiloadTest(unittest.TestCase):
 
 class PublishDeleteAPITests(unittest.TestCase):
 
-    DATASET_NAME='owner:datasetid'
+    DATASET_NAME = 'owner:datasetid'
 
     def setUp(self):
         # Clean index
@@ -154,7 +161,8 @@ class PublishDeleteAPITests(unittest.TestCase):
         time.sleep(1)
 
         self.pr = PackageRegistry(es_connection_string=LOCAL_ELASTICSEARCH)
-        self.pr.save_model(self.DATASET_NAME, 'datapackage_url', {}, {}, 'dataset', 'author', '', True)
+        self.pr.save_model(self.DATASET_NAME, 'datapackage_url', {}, {},
+                           'dataset', 'author', '', True)
 
     def test__initial_value__none(self):
         pkg = self.pr.get_package(self.DATASET_NAME)
@@ -208,5 +216,7 @@ class PublishDeleteAPITests(unittest.TestCase):
 
 class StatsTests(unittest.TestCase):
     def test__stats__delegates_to_package_registry(self):
-        with patch('conductor.blueprints.package.models.package_registry.get_stats') as get_stats_mock:
+        stats_path = \
+            'conductor.blueprints.package.models.package_registry.get_stats'
+        with patch(stats_path) as get_stats_mock:
             assert module.stats() == get_stats_mock()

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
   nose
   coverage
 commands =
-  nosetests tests \
+  nosetests -w tests \
     {posargs} \
     --with-coverage \
     --cover-package conductor


### PR DESCRIPTION
Update `defaultParams` property for a package entry managed by os-package-registry (elasticsearch).

- Check owner of the package is same as user in the jwt
- Update package model 'defaultParams' property with the passed json in the request body. 
- Clear the os-api cache for the package.

Part of openspending/openspending#1187