### PR TITLE
Bump dpp-fiscal version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ cryptography
 elasticsearch>=1.0.0,<2.0.0
 os-api-cache>=0.0.6
 os-package-registry>=0.0.13
-datapackage-pipelines-fiscal>=1.0.7
+datapackage-pipelines-fiscal>=1.0.8
 datapackage-pipelines-aws
 datapackage-pipelines[speedup]
 dpp_runner

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ cryptography
 elasticsearch>=1.0.0,<2.0.0
 os-api-cache>=0.0.6
 os-package-registry>=0.0.13
-datapackage-pipelines-fiscal>=1.0.8
+datapackage-pipelines-fiscal>=1.0.9
 datapackage-pipelines-aws
 datapackage-pipelines[speedup]
 dpp_runner


### PR DESCRIPTION
This PR should resolve the 'failed to cast number' errors that are popping lately.

Problem was that in the pipeline, groupChar was ignored at some point so I added a step to cast the numeric values before that happens.

(actual fix is in dpp-fiscal)