### PR TITLE
Ensure kw arg is a list before iterating

### DIFF
--- a/conductor/blueprints/search/models.py
+++ b/conductor/blueprints/search/models.py
@@ -79,6 +79,8 @@ def build_dsl(kind_params, userid, kw):
             })
     for k, v_arr in kw.items():
         if k.split('.')[0] in kind_params['_source']:
+            if not isinstance(v_arr, list):
+                v_arr = [v_arr]
             dsl['bool']['must'].append({
                     'bool': {
                         'should': [{'match': {k: json.loads(v)}}

--- a/conductor/blueprints/search/models.py
+++ b/conductor/blueprints/search/models.py
@@ -71,6 +71,8 @@ def build_dsl(kind_params, userid, kw):
     # Query parameters
     q = kw.get('q')
     if q is not None:
+        if not isinstance(q, list):
+            q = [q]
         dsl['bool']['must'].append({
                 'multi_match': {
                     'query': json.loads(q[0]),


### PR DESCRIPTION
Occasionally, the passed keyword arg isn't passed as a list, which breaks the dsl query construction when there's an attempt to iterate and `json.load` the value.